### PR TITLE
Handle empty url64bit correctly

### DIFF
--- a/WASP/Private/Install-ChocolateyInstallPackage.ps1
+++ b/WASP/Private/Install-ChocolateyInstallPackage.ps1
@@ -152,7 +152,7 @@ function Install-ChocolateyInstallPackage() {
     # Check the url found above ($url or $url64bit) and download the file
     if ($null -ne $url) {
         $urlFound = $url
-    } elseif ($null -ne $url64bit) {
+    } elseif ($url64bit -ne '' -and $null -ne $url64bit) {
         $urlFound = $url64bit
     }    
 

--- a/WASP/Private/Install-ChocolateyPackage.ps1
+++ b/WASP/Private/Install-ChocolateyPackage.ps1
@@ -40,7 +40,7 @@ function Install-ChocolateyPackage() {
     # Check the url found above ($url or $url64bit) and download the file
     if ($null -ne $url) {
         $urlFound = $url
-    } elseif ($null -ne $url64bit) {
+    } elseif ($url64bit -ne '' -and $null -ne $url64bit) {
         $urlFound = $url64bit
     }    
 

--- a/WASP/Private/Install-ChocolateyPowershellCommand.ps1
+++ b/WASP/Private/Install-ChocolateyPowershellCommand.ps1
@@ -34,7 +34,7 @@ function Install-ChocolateyPowershellCommand() {
     # Check the url found above ($url or $url64bit) and download the file
     if ($null -ne $url) {
         $urlFound = $url
-    } elseif ($null -ne $url64bit) {
+    } elseif ($url64bit -ne '' -and $null -ne $url64bit) {
         $urlFound = $url64bit
     }    
 

--- a/WASP/Private/Install-ChocolateyZipPackage.ps1
+++ b/WASP/Private/Install-ChocolateyZipPackage.ps1
@@ -119,7 +119,7 @@ function Install-ChocolateyZipPackage() {
     # Check the url found above ($url or $url64bit) and download the file
     if ($null -ne $url) {
         $urlFound = $url
-    } elseif ($null -ne $url64bit) {
+    } elseif ($url64bit -ne '' -and $null -ne $url64bit) {
         $urlFound = $url64bit
     }    
 


### PR DESCRIPTION
Hi Uwe, 

ich habe da einen Bug durch den letzten Change mit der Reihenfolge vom url check gefunden. In manchen Powershell funktionen wird dem url64bit parameter ein leerer String ('') zugewiesen. Der nicht null check reicht da nicht aus und es wird der Variable urlFound dann ein leerer String ('') zugewiesen. Dies führt dann zu folgendem Fehler im Workflow:
![telegram-cloud-photo-size-2-5219680416779336592-y](https://github.com/user-attachments/assets/222f5cb4-b287-4739-ac04-2defb5a42510)

Ich habe den Fehler behoben, in dem ich in jedem null check zusaetzlich nach einem empty String ('') checke.

Gruss
Julian

